### PR TITLE
Prevent extra calculations / Extra calls of EndVersusModeRound engine function

### DIFF
--- a/detours/end_versus_mode_round.cpp
+++ b/detours/end_versus_mode_round.cpp
@@ -38,6 +38,9 @@ namespace Detours
 	{
 		L4D_DEBUG_LOG("CDirectorVersusMode::EndVersusModeRound(%s) has been called", countSurvivors ? "true" : "false");
 		
+		if(g_bRoundEnd) return;
+		g_bRoundEnd = true;
+		
 		cell_t result = Pl_Continue;
 		if(g_pFwdOnEndVersusModeRound)
 		{
@@ -50,6 +53,11 @@ namespace Detours
 		
 		(this->*(GetTrampoline()))(countSurvivors);
 
+		if(g_pFwdOnEndVersusModeRound_Post)
+		{
+			L4D_DEBUG_LOG("L4D2_OnEndVersusModeRound_Post forward has been sent out");
+			g_pFwdOnEndVersusModeRound_Post->Execute(NULL);
+		}
 	   
 		return;
 	}

--- a/detours/first_survivor_left_safe_area.cpp
+++ b/detours/first_survivor_left_safe_area.cpp
@@ -69,6 +69,7 @@ namespace Detours
 		}
 		else
 		{
+			g_bRoundEnd = false;
 			return (this->*(GetTrampoline()))(p);
 		}
 	}

--- a/extension.cpp
+++ b/extension.cpp
@@ -120,10 +120,13 @@ IForward *g_pFwdOnStartMeleeSwing = NULL;
 IForward *g_pFwdOnSendInRescueVehicle = NULL;
 IForward *g_pFwdOnChangeFinaleStage = NULL;
 IForward *g_pFwdOnEndVersusModeRound = NULL;
+IForward *g_pFwdOnEndVersusModeRound_Post = NULL;
 IForward *g_pFwdOnSelectTankAttack = NULL;
 IForward *g_pFwdOnRevived = NULL;
 IForward *g_pFwdOnAddonsEclipseUpdate = NULL;
 IForward *g_pFwdOnNavAreaChanged = NULL;
+
+bool g_bRoundEnd = false;
 
 ICvar *icvar = NULL;
 SMEXT_LINK(&g_Left4DowntownTools);
@@ -207,6 +210,7 @@ bool Left4Downtown::SDK_OnLoad(char *error, size_t maxlength, bool late)
 	g_pFwdOnSendInRescueVehicle = forwards->CreateForward("L4D2_OnSendInRescueVehicle", ET_Event, 0, /*types*/NULL);
 	g_pFwdOnChangeFinaleStage = forwards->CreateForward("L4D2_OnChangeFinaleStage", ET_Event, 2, /*types*/NULL, Param_CellByRef, Param_String);
 	g_pFwdOnEndVersusModeRound = forwards->CreateForward("L4D2_OnEndVersusModeRound", ET_Event, 1, /*types*/NULL, Param_Cell);
+	g_pFwdOnEndVersusModeRound_Post = forwards->CreateForward("L4D2_OnEndVersusModeRound_Post", ET_Ignore, 0, /*types*/NULL);
 	g_pFwdOnSelectTankAttack = forwards->CreateForward("L4D2_OnSelectTankAttack", ET_Event, 2, /*types*/NULL, Param_Cell, Param_CellByRef);
 	g_pFwdOnRevived = forwards->CreateForward("L4D_OnRevived", ET_Event, 1, /*types*/NULL, Param_Cell);
 	g_pFwdOnAddonsEclipseUpdate = forwards->CreateForward("L4D2_OnAddonsEclipseUpdate", ET_Event, 1, /*types*/NULL, Param_Cell);
@@ -362,6 +366,7 @@ void Left4Downtown::SDK_OnUnload()
 	forwards->ReleaseForward(g_pFwdOnSendInRescueVehicle);
 	forwards->ReleaseForward(g_pFwdOnChangeFinaleStage);
 	forwards->ReleaseForward(g_pFwdOnEndVersusModeRound);
+	forwards->ReleaseForward(g_pFwdOnEndVersusModeRound_Post);
 	forwards->ReleaseForward(g_pFwdOnSelectTankAttack);
 	forwards->ReleaseForward(g_pFwdOnRevived);
 	forwards->ReleaseForward(g_pFwdOnAddonsEclipseUpdate);
@@ -457,7 +462,6 @@ void Left4Downtown::OnClientAuthorized(int client, const char *authstring)
 	// When done with event, must destroy it manually
 	gameeventmanager->FreeEvent(pEvent);  
 }
-
 #ifdef USE_PLAYERSLOTS_PATCHES
 	/**
 	 * @brief Called when the server is activated.

--- a/extension.h
+++ b/extension.h
@@ -176,9 +176,12 @@ extern IForward *g_pFwdOnStartMeleeSwing;
 extern IForward *g_pFwdOnSendInRescueVehicle;
 extern IForward *g_pFwdOnChangeFinaleStage;
 extern IForward *g_pFwdOnEndVersusModeRound;
+extern IForward *g_pFwdOnEndVersusModeRound_Post;
 extern IForward *g_pFwdOnSelectTankAttack;
 extern IForward *g_pFwdOnRevived;
 extern IForward *g_pFwdOnNavAreaChanged;
+
+extern bool g_bRoundEnd;
 
 extern IBinTools *g_pBinTools;
 extern IServer *g_pServer; //pointer to CBaseServer

--- a/scripting/include/left4downtown.inc
+++ b/scripting/include/left4downtown.inc
@@ -333,6 +333,14 @@ forward Action:L4D2_OnChangeFinaleStage(&finaleType, const String:arg[]);
 forward Action:L4D2_OnEndVersusModeRound(bool:countSurvivors);
 
 /**
+ * @brief Called after CDirectorVersusMode::EndVersusModeRound(bool)
+ * @remarks Called after all score calculations inside CDirectorVersusMode::EndVersusModeRound(bool). This good forward to replace standard "round_end" hook.
+ * 
+ * @return 		noreturn
+ */
+forward L4D2_OnEndVersusModeRound_Post();
+
+/**
  * @brief Called when CBaseAnimating::SelectWeightedSequence(int Activity) is invoked with tank attack activity
  * @remarks Called whenever a tank uses his primary (punch) or secondary (throw) attack
  *


### PR DESCRIPTION
Function EndVersusModeRound should called twice: for first and second round. In this function placed all score calculations and when it run very often — it's problem, server can crashed.

In this patch i'm block extra calls EndVersusModeRound and add new forward:
public L4D2_OnEndVersusModeRound_Post()
