### PR TITLE
OnPlayerDisconnect > IsFakeClient Id 0 not valid

### DIFF
--- a/scripting/l4d2_unreservelobby.sp
+++ b/scripting/l4d2_unreservelobby.sp
@@ -92,6 +92,9 @@ public Action:OnPlayerDisconnect(Handle:event, const String:name[], bool:dontBro
 {
 	new client = GetClientOfUserId(GetEventInt(event, "userid"));
 
+	if (client == 0)
+		return;
+
 	if (IsFakeClient(client))
 		return;
 	


### PR DESCRIPTION
Linux server log:
L 06/19/2018 - 23:20:45: [SM] Exception reported: Client index 0 is invalid
L 06/19/2018 - 23:20:45: [SM] Blaming: l4d2_unreservelobby.smx
L 06/19/2018 - 23:20:45: [SM] Call stack trace:
L 06/19/2018 - 23:20:45: [SM]   [0] IsFakeClient
L 06/19/2018 - 23:20:45: [SM]   [1] Line 95, D:\Users\Anime4000\Documents\GitLab\lewd4dead\left4dead2\addons\sourcemod\scripting\l4d2_unreservelobby.sp::OnPlayerDisconnect